### PR TITLE
rename ssid to "Weimarnetz Freifunk"

### DIFF
--- a/utils/data-weimar/files/etc/uci-defaults/30-freifunk.sh
+++ b/utils/data-weimar/files/etc/uci-defaults/30-freifunk.sh
@@ -6,7 +6,7 @@ uci -m import profile_Weimar <<EOF
 config community 'profile'
 	option 'name' 'Weimar'
 	option 'homepage' 'http://www.weimarnetz.de'
-	option 'ssid' 'weimar.freifunk.net'
+	option 'ssid' 'Weimarnetz Freifunk'
 	option 'mesh_ssid' 'mesh.%d.ch%d.weimarnetz.de'
 	option 'ap_ssid' 'weimarnetz.de | %s' 
 	option 'mesh_network' '10.63.0.0/16'


### PR DESCRIPTION
to make AP more visible change AP-SSID to "Weimarnetz Freifunk"