### PR TITLE
Create ramips__mt7621_generic.profiles

### DIFF
--- a/assemble/profiles/trunk/ramips__mt7621_generic.profiles
+++ b/assemble/profiles/trunk/ramips__mt7621_generic.profiles
@@ -1,0 +1,1 @@
+tplink_archer-c6-v3;-kmod-ath10k-ct kmod-ath10k-smallbuffers -ath10k-firmware-qca9888-ct ath10k-firmware-qca9888


### PR DESCRIPTION
addes suppor for TP-Link Archer C6 v3